### PR TITLE
フラッシュメッセージの作成

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ ruby "3.2.2"
 gem "pry-byebug", group: :development
 gem 'rails-i18n', '~> 7.0.0'
 gem 'devise-i18n'
+gem 'devise-i18n-views'
 
 gem "devise", "~> 4.9", ">= 4.9.3"
 gem 'omniauth-google-oauth2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,6 +119,7 @@ GEM
       warden (~> 1.2.3)
     devise-i18n (1.12.0)
       devise (>= 4.9.0)
+    devise-i18n-views (0.3.7)
     dotenv (3.1.0)
     dotenv-rails (3.1.0)
       dotenv (= 3.1.0)
@@ -345,6 +346,7 @@ DEPENDENCIES
   debug
   devise (~> 4.9, >= 4.9.3)
   devise-i18n
+  devise-i18n-views
   dotenv-rails
   importmap-rails
   jbuilder

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -6,11 +6,10 @@ class AnswersController < ApplicationController
   def create
     answer = current_user.answers.build(answer_params)
     if  answer.save
-      flash[:success] = '投稿に成功しました'
       redirect_to question_path(answer.question), success: t('defaults.flash_messages.created', item: Answer.model_name.human)
     else
-      flash[:danger] = '投稿に失敗しました'
-      redirect_to question_path(answer.question), danger: t('defaults.flash_messages.not_created', item: Answer.model_name.human)
+      flash.now[:danger] = t('defaults.flash_messages.not_created', item: Answer.model_name.human)
+      render :new, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,10 +1,11 @@
 class ApplicationController < ActionController::Base
-    before_action :configure_permitted_parameters, if: :devise_controller?
-   
-    protected
+  before_action :configure_permitted_parameters, if: :devise_controller?
+  add_flash_types :success, :danger
+  
+  protected
 
-    def configure_permitted_parameters
-       #以下の:name部分は追加したカラム名に変える
-       devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
-    end
+  def configure_permitted_parameters
+      #以下の:name部分は追加したカラム名に変える
+      devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
+  end
 end    

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -29,21 +29,20 @@ class QuestionsController < ApplicationController
     @question = current_user.questions.build(question_params)
 
       if @question.save
-        flash[:success] = '投稿に成功しました'
-        redirect_to @question
+        redirect_to @question, success: t('defaults.flash_messages.created', item: Question.model_name.human)
       else
-        flash.now[:danger] = '投稿に失敗しました'
+        flash.now[:danger] = t('defaults.flash_messages.not_created', item: Question.model_name.human)
         render :new, status: :unprocessable_entity
       end
   end
 
   # PATCH/PUT /questions/1 or /questions/1.json
   def update
-    @question = current_user.question.find(params[:id])
+    @question = current_user.questions.find(params[:id])
     if @question.update(question_params)
-      redirect_to @question, success: '編集に成功しました'
+      redirect_to @question, success: t('defaults.flash_messages.updated', item: Question.model_name.human)
     else
-      flash.now[:danger] = '編集に失敗しました'
+      flash.now[:danger] = t('defaults.flash_messages.not_updated', item: Question.model_name.human)
       render :edit, status: :unprocessable_entity
     end
   end
@@ -52,7 +51,7 @@ class QuestionsController < ApplicationController
   def destroy
     question = current_user.questions.find(params[:id])
     @question.destroy!
-    redirect_to questions_path, notice: '質問を削除しました'
+    redirect_to questions_path, danger: t('defaults.flash_messages.deleted', item: Question.model_name.human)
   end
 
   private

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -29,7 +29,7 @@
     </div>
     <div class=text-center>
       <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-        <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
+        <%= link_to t('.forgot_your_password'), new_password_path(resource_name) %><br />
       <% end %>
 
       <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -7,7 +7,7 @@
 <% end %>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
+  <%= link_to t('.forgot_your_password'), new_password_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -1,9 +1,4 @@
 <div class="mx-auto md:w-2/3 w-full flex flex-col space-y-5 overflow-auto px-4">
-  <% if notice.present? %>
-    <div class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg" id="notice">
-      <%= notice %>
-    </div>
-  <% end %>
 
   <%= render @question %>
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,6 +14,9 @@ module MyApp
     config.time_zone = 'Tokyo'
 		config.active_record.default_timezone = :local
 		config.i18n.default_locale = :ja
+    # 複数のlacalesを読み込む
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
+
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -1,0 +1,32 @@
+ja:
+  activerecord:
+    models:
+      user: ユーザー
+      question: 質問
+      answer: 回答
+    attributes:
+      user:
+        email: メールアドレス
+        last_name: 姓
+        first_name: 名
+        full_name: 氏名
+        avatar: アバター
+        password: パスワード
+        password_confirmation: パスワード確認
+        role: 権限
+      question:
+        title: タイトル
+        body: 本文
+        question_image: サムネイル
+        user: 作成者
+      answer:
+        body: コメント
+  attributes:
+    id: ID
+    created_at: 作成日時
+    updated_at: 更新日時
+  enums:
+    user:
+      role:
+        general: 一般
+        admin: 管理者

--- a/config/locales/device.en.yml
+++ b/config/locales/device.en.yml
@@ -18,7 +18,7 @@ ja:
       signed_in: "正常にログインしました。"
       signed_out: "正常にログアウトしました。"
       already_signed_out: "すでにログアウトしました。"
-      Forgot_your_password?: "パスワードをお忘れですか？"
+      forgot_your_password?: "パスワードをお忘れですか？"
     unlocks:
       send_instructions: "数分以内にアカウントのロックを解除する方法についての指示が記載されたメールが送信されます。"
       send_paranoid_instructions: "アカウントが存在する場合は、数分以内にロックを解除する方法についての指示が記載されたメールが送信されます。"

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,85 @@
+ja:
+  activerecord:
+    errors:
+      models:
+        user:
+          attributes:
+            email:
+              taken: "は既に使用されています。"
+              blank: "が入力されていません。"
+              too_short: "は%{count}文字以上に設定して下さい。"
+              too_long: "は%{count}文字以下に設定して下さい。"
+              invalid: "は有効でありません。"
+            password:
+              taken: "は既に使用されています。"
+              blank: "が入力されていません。"
+              too_short: "は%{count}文字以上に設定して下さい。"
+              too_long: "は%{count}文字以下に設定して下さい。"
+              invalid: "は有効でありません。"
+              confirmation: "が内容とあっていません。"
+    attributes:
+      user:
+        current_password: "現在のパスワード"
+        name: 名前
+        email: "メールアドレス"
+        password: "パスワード"
+        password_confirmation: "確認用パスワード"
+        remember_me: "次回から自動的にログイン"
+    models:
+      user: "ユーザ"
+  devise:
+    confirmations:
+      new:
+        resend_confirmation_instructions: "アカウント確認メール再送"
+    mailer:
+      confirmation_instructions:
+        action: "アカウント確認"
+        greeting: "ようこそ、%{recipient}さん!"
+        instruction: "次のリンクでメールアドレスの確認が完了します:"
+      reset_password_instructions:
+        action: "パスワード変更"
+        greeting: "こんにちは、%{recipient}さん!"
+        instruction: "誰かがパスワードの再設定を希望しました。次のリンクでパスワードの再設定が出来ます。"
+        instruction_2: "あなたが希望したのではないのなら、このメールは無視してください。"
+        instruction_3: "上のリンクにアクセスして新しいパスワードを設定するまで、パスワードは変更されません。"
+      unlock_instructions:
+        action: "アカウントのロック解除"
+        greeting: "こんにちは、%{recipient}さん!"
+        instruction: "アカウントのロックを解除するには下のリンクをクリックしてください。"
+        message: "ログイン失敗が繰り返されたため、アカウントはロックされています。"
+    passwords:
+      edit:
+        change_my_password: "パスワードを変更する"
+        change_your_password: "パスワードを変更"
+        confirm_new_password: "確認用新しいパスワード"
+        new_password: "新しいパスワード"
+      new:
+        forgot_your_password: "パスワードを忘れましたか?"
+        send_me_reset_password_instructions: "パスワードの再設定方法を送信する"
+    registrations:
+      edit:
+        are_you_sure: "本当に良いですか?"
+        cancel_my_account: "アカウント削除"
+        currently_waiting_confirmation_for_email: "%{email} の確認待ち"
+        leave_blank_if_you_don_t_want_to_change_it: "空欄のままなら変更しません"
+        title: "%{resource}編集"
+        unhappy: "気に入りません"
+        update: "更新"
+        we_need_your_current_password_to_confirm_your_changes: "変更を反映するには現在のパスワードを入力してください"
+      new:
+        sign_up: "アカウント登録"
+    sessions:
+      new:
+        sign_in: "ログイン"
+    shared:
+      links:
+        back: "戻る"
+        didn_t_receive_confirmation_instructions: "アカウント確認のメールを受け取っていませんか?"
+        didn_t_receive_unlock_instructions: "アカウントの凍結解除方法のメールを受け取っていませんか?"
+        forgot_your_password: "パスワードを忘れましたか?"
+        sign_in: "ログイン"
+        sign_in_with_provider: "%{provider}でログイン"
+        sign_up: "アカウント登録"
+    unlocks:
+      new:
+        resend_unlock_instructions: "アカウントの凍結解除方法を再送する"

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -1,0 +1,44 @@
+ja:
+  helpers:
+    submit:
+      create: 登録
+      submit: 保存
+      update: 更新
+    label:
+      email: メールアドレス
+      password: パスワード
+  defaults:
+    create: 作成
+    post: 投稿
+    edit: 編集
+    show: 詳細
+    delete: 削除
+    delete_confirm: 削除しますか？
+    password_reset: パスワードリセット
+    unspecified: 指定なし
+    flash_messages:
+      created: "%{item}を作成しました"
+      not_created: "%{item}を作成出来ませんでした"
+      updated: "%{item}を更新しました"
+      not_updated: "%{item}を更新出来ませんでした"
+      deleted: "%{item}を削除しました"
+      require_login: ログインしてください
+      not_authorized: 権限がありません
+  user_sessions:
+    new:
+      title: ログイン
+      login: ログイン
+      to_register_page: 登録ページへ
+      password_forget: パスワードをお忘れの方はこちら
+  users:
+    new:
+      title: ユーザー登録
+      to_login_page: ログインページへ
+  header:
+    login: ログイン
+    logout: ログアウト
+    question: 質問
+    question_index: 質問一覧
+    create_question: 質問作成
+    bookmark_index: ブックマーク一覧
+    profile: プロフィール


### PR DESCRIPTION
# 概要
issueの13と14
## 実装内容
以下のフラッシュメッセージの作成
- [x] 質問投稿時
- [x] 質問投稿失敗時
- [x] 質問投稿編集時
- [x] 質問投稿編集失敗時
- [x] 質問投稿削除時

deviceの機能を使って以下は実装
- [x] 新規登録時
- [x] 新規登録失敗時
- [x] ログイン時
- [x] ログイン失敗時
- [x] ログアウト

#13 
#14 
